### PR TITLE
perf: remove redundant Cows

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -103,7 +103,7 @@ mod tests {
                     let values = tokenizer
                         .tokenize(inp)
                         .map(Result::unwrap)
-                        .map(|token| token.value.clone())
+                        .map(|token| token.value)
                         .collect::<Vec<_>>();
                     assert_eq!(values, expected_values);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,7 @@ mod tests {
         if let Ok(tokens) = tok.tokenize(",[.,]").collect::<Result<Vec<_>, _>>() {
             assert!(tokens
                 .iter()
-                .map(|t| t.name.clone())
+                .map(|t| t.name)
                 .eq("read begin_loop write read end_loop".split_whitespace()));
         } else {
             panic!();

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 /// Represents a lexical token with a name/type and its raw value from the source code.
 ///
 /// Used to represent the output of the [`Tokenizer`][crate::Tokenizer] struct.
@@ -16,9 +14,9 @@ use std::borrow::Cow;
 #[derive(Debug, PartialEq, Eq)]
 pub struct Token<'a> {
     /// The type or category of the token (e.g., "int", "identifier", "operator").
-    pub name: Cow<'a, str>,
+    pub name: &'a str,
     /// The actual text/value from the source code that this token represents.
-    pub value: Cow<'a, str>,
+    pub value: &'a str,
     /// The position of the token in the source code.
     /// * For [`Tokenizer::tokenize`], this is the byte offset from the start of the entire source.
     /// * For [`Tokenizer::tokenize_lines`], this is the byte offset from the start of each line.
@@ -31,8 +29,8 @@ pub struct Token<'a> {
 impl<'a> From<(&'a str, &'a str, usize)> for Token<'a> {
     fn from(value: (&'a str, &'a str, usize)) -> Self {
         Token {
-            name: Cow::Borrowed(value.0),
-            value: Cow::Borrowed(value.1),
+            name: value.0,
+            value: value.1,
             position: value.2,
         }
     }


### PR DESCRIPTION
There are no places left, where an owned string would be returned, so the `Cow`s are not needed anymore. And it also saves few bytes and CPU branches, which is always nice.